### PR TITLE
Add Ruby 3.2 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ the [AWS CLI](https://aws.amazon.com/cli/).
     - [python3.9](#python39)
     - [python3.10](#python310)
     - [ruby2.7](#ruby27)
+    - [ruby3.2](#ruby32)
     - [java8.al2](#java8al2)
     - [java11](#java11)
     - [dotnetcore3.1](#dotnetcore31)
@@ -202,6 +203,24 @@ Build images
 | Universal | `mlupin/docker-lambda:ruby2.7-build`        | `ghcr.io/mlupine/docker-lambda:ruby2.7-build`        |
 | x86_64    | `mlupin/docker-lambda:ruby2.7-build-x86_64` | `ghcr.io/mlupine/docker-lambda:ruby2.7-build-x86_64` |
 | arm64     | `mlupin/docker-lambda:ruby2.7-build-arm64`  | `ghcr.io/mlupine/docker-lambda:ruby2.7-build-arm64`  |
+
+### ruby3.2
+
+Runtime images
+
+| Platform  | Docker Hub                            | GitHub Container Registry                      |
+| --------- | ------------------------------------- | ---------------------------------------------- |
+| Universal | `mlupin/docker-lambda:ruby3.2`        | `ghcr.io/mlupine/docker-lambda:ruby3.2`        |
+| x86_64    | `mlupin/docker-lambda:ruby3.2-x86_64` | `ghcr.io/mlupine/docker-lambda:ruby3.2-x86_64` |
+| arm64     | `mlupin/docker-lambda:ruby3.2-arm64`  | `ghcr.io/mlupine/docker-lambda:ruby3.2-arm64`  |
+
+Build images
+
+| Platform  | Docker Hub                                  | GitHub Container Registry                            |
+| --------- | ------------------------------------------- | ---------------------------------------------------- |
+| Universal | `mlupin/docker-lambda:ruby3.2-build`        | `ghcr.io/mlupine/docker-lambda:ruby3.2-build`        |
+| x86_64    | `mlupin/docker-lambda:ruby3.2-build-x86_64` | `ghcr.io/mlupine/docker-lambda:ruby3.2-build-x86_64` |
+| arm64     | `mlupin/docker-lambda:ruby3.2-build-arm64`  | `ghcr.io/mlupine/docker-lambda:ruby3.2-build-arm64`  |
 
 ### java8.al2
 

--- a/dump-fs/dump-ruby32/handler.rb
+++ b/dump-fs/dump-ruby32/handler.rb
@@ -1,0 +1,40 @@
+require 'json'
+require 'aws-sdk-s3'
+
+S3_CLIENT = Aws::S3::Client.new({region: "eu-central-1"})
+
+def lambda_handler(event, context, arch)
+  filename = "ruby3.2-#{arch}.tgz"
+
+  puts `touch /tmp/#{filename}`
+  puts `tar -cpzf /tmp/#{filename} --numeric-owner --ignore-failed-read /var/runtime /var/lang /var/rapid`
+
+  File.open("/tmp/#{filename}", 'rb') do |file|
+    S3_CLIENT.put_object({
+      body: file,
+      bucket: 'docker-lambda',
+      key: "fs/#{filename}",
+      acl: 'public-read',
+    })
+  end
+
+  info = {
+    'ENV' => ENV.to_hash,
+    'context' => context.instance_variables.each_with_object({}) { |k, h| h[k] = context.instance_variable_get k },
+    'ps aux' => `bash -O extglob -c 'for cmd in /proc/+([0-9])/cmdline; do echo $cmd; xargs -n 1 -0 < $cmd; done'`,
+    'proc environ' => `xargs -n 1 -0 < /proc/1/environ`,
+  }
+
+  print JSON.pretty_generate(info)
+
+  return info
+end
+
+
+def lambda_handler_x86_64(event:, context:)
+  return lambda_handler event, context, "x86_64"
+end
+
+def lambda_handler_arm64(event:, context:)
+  return lambda_handler event, context, "arm64"
+end

--- a/dump-fs/serverless.yml
+++ b/dump-fs/serverless.yml
@@ -136,6 +136,27 @@ functions:
     layers:
       - { Ref: TarARMLambdaLayer }
 
+  dump-ruby32-x86_64:
+    handler: dump-ruby32/handler.lambda_handler_x86_64
+    package:
+      patterns:
+        - "!**"
+        - "dump-ruby32/**"
+    runtime: ruby3.2
+    architecture: x86_64
+    layers:
+      - { Ref: TarX86LambdaLayer }
+  dump-ruby32-arm64:
+    handler: dump-ruby32/handler.lambda_handler_arm64
+    package:
+      patterns:
+        - "!**"
+        - "dump-ruby32/**"
+    runtime: ruby3.2
+    architecture: arm64
+    layers:
+      - { Ref: TarARMLambdaLayer }
+
   dump-dotnetcore31-x86_64:
     handler: dump_dotnetcore31::dump_dotnetcore31.Function::FunctionHandler_x86_64
     package:

--- a/examples/ruby/lambda_function.rb
+++ b/examples/ruby/lambda_function.rb
@@ -2,6 +2,7 @@ require 'pp'
 
 # docker run --rm -v "$PWD":/var/task mlupin/docker-lambda:ruby2.5 lambda_function.lambda_handler
 # docker run --rm -v "$PWD":/var/task mlupin/docker-lambda:ruby2.7 lambda_function.lambda_handler
+# docker run --rm -v "$PWD":/var/task mlupin/docker-lambda:ruby3.2 lambda_function.lambda_handler
 
 def lambda_handler(event:, context:)
   info = {

--- a/examples/test-all.sh
+++ b/examples/test-all.sh
@@ -27,6 +27,7 @@ docker run --rm -it mlupin/docker-lambda:python3.10-build pip install marisa-tri
 
 cd ${EXAMPLES_DIR}/ruby
 docker run --rm -v "$PWD":/var/task mlupin/docker-lambda:ruby2.7 lambda_function.lambda_handler
+docker run --rm -v "$PWD":/var/task mlupin/docker-lambda:ruby3.2 lambda_function.lambda_handler
 
 cd ${EXAMPLES_DIR}/java
 docker run --rm -v "$PWD":/app -w /app mlupin/docker-lambda:java8.al2-build gradle build

--- a/runtimes/ruby3.2-arm64/build/Dockerfile
+++ b/runtimes/ruby3.2-arm64/build/Dockerfile
@@ -1,0 +1,23 @@
+FROM mlupin/docker-lambda:ruby3.2-arm64
+
+FROM mlupin/docker-lambda:build-arm64
+
+ENV PATH=/var/lang/bin:$PATH \
+  LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
+  AWS_EXECUTION_ENV=AWS_Lambda_ruby3.2 \
+  AWS_EXECUTION_ARCH=arm64 \
+  GEM_HOME=/var/runtime \
+  GEM_PATH=/var/task/vendor/bundle/ruby/3.2.0:/opt/ruby/gems/3.2.0:/var/lang/lib/ruby/gems/3.2.0 \
+  RUBYLIB=/var/task:/var/runtime/lib:/opt/ruby/lib \
+  BUNDLE_SILENCE_ROOT_WARNING=1
+
+COPY --from=0 /var/runtime /var/runtime
+COPY --from=0 /var/lang /var/lang
+COPY --from=0 /var/rapid /var/rapid
+
+# Add these as a separate layer as they get updated frequently
+RUN pipx install awscli==1.* && \
+  pipx install aws-lambda-builders==1.2.0 && \
+  pipx install aws-sam-cli==1.15.0 && \
+  gem update --system --no-document && \
+  gem install --no-document bundler -v '~> 2.1'

--- a/runtimes/ruby3.2-arm64/build/build.sh
+++ b/runtimes/ruby3.2-arm64/build/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+docker build --progress plain --squash -t mlupin/docker-lambda:ruby3.2-build-arm64 .

--- a/runtimes/ruby3.2-arm64/build/publish.sh
+++ b/runtimes/ruby3.2-arm64/build/publish.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+export PUBLISH_DATE=$(date "+%Y%m%d%H%M")
+export NO_ARCH_TAG="mlupin/docker-lambda:ruby3.2-build"
+export BASE_IMAGE="${NO_ARCH_TAG}-arm64"
+
+docker tag ${BASE_IMAGE} ${BASE_IMAGE}-${PUBLISH_DATE}
+docker push ${BASE_IMAGE}
+docker push ${BASE_IMAGE}-${PUBLISH_DATE}

--- a/runtimes/ruby3.2-arm64/run/Dockerfile
+++ b/runtimes/ruby3.2-arm64/run/Dockerfile
@@ -1,0 +1,21 @@
+FROM arm64v8/amazonlinux:2
+
+RUN yum install -y tar gzip
+
+RUN curl https://docker-lambda.s3.amazonaws.com/fs/ruby3.2-arm64.tgz | tar -zx -C /opt
+
+FROM mlupin/docker-lambda:provided.al2-arm64
+FROM mlupin/docker-lambda:base-arm64
+
+ENV PATH=/var/lang/bin:$PATH \
+    LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
+    AWS_EXECUTION_ENV=AWS_Lambda_ruby3.2 \
+    AWS_EXECUTION_ARCH=arm64
+
+COPY --from=0 /opt/* /var/
+
+COPY --from=1 /var/runtime/init /var/rapid/init
+
+USER sbx_user1051
+
+ENTRYPOINT ["/var/rapid/init", "--bootstrap", "/var/runtime/bootstrap", "--enable-msg-logs"]

--- a/runtimes/ruby3.2-arm64/run/build.sh
+++ b/runtimes/ruby3.2-arm64/run/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+docker build --progress plain --squash -t mlupin/docker-lambda:ruby3.2-arm64 .

--- a/runtimes/ruby3.2-arm64/run/publish.sh
+++ b/runtimes/ruby3.2-arm64/run/publish.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+export PUBLISH_DATE=$(date "+%Y%m%d%H%M")
+export NO_ARCH_TAG="mlupin/docker-lambda:ruby3.2"
+export BASE_IMAGE="${NO_ARCH_TAG}-arm64"
+
+docker tag ${BASE_IMAGE} ${BASE_IMAGE}-${PUBLISH_DATE}
+docker push ${BASE_IMAGE}
+docker push ${BASE_IMAGE}-${PUBLISH_DATE}

--- a/runtimes/ruby3.2-x86_64/build/Dockerfile
+++ b/runtimes/ruby3.2-x86_64/build/Dockerfile
@@ -1,0 +1,23 @@
+FROM mlupin/docker-lambda:ruby3.2-x86_64
+
+FROM mlupin/docker-lambda:build-x86_64
+
+ENV PATH=/var/lang/bin:$PATH \
+  LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
+  AWS_EXECUTION_ENV=AWS_Lambda_ruby3.2 \
+  AWS_EXECUTION_ARCH=x86_64 \
+  GEM_HOME=/var/runtime \
+  GEM_PATH=/var/task/vendor/bundle/ruby/3.2.0:/opt/ruby/gems/3.2.0:/var/lang/lib/ruby/gems/3.2.0 \
+  RUBYLIB=/var/task:/var/runtime/lib:/opt/ruby/lib \
+  BUNDLE_SILENCE_ROOT_WARNING=1
+
+COPY --from=0 /var/runtime /var/runtime
+COPY --from=0 /var/lang /var/lang
+COPY --from=0 /var/rapid /var/rapid
+
+# Add these as a separate layer as they get updated frequently
+RUN pipx install awscli==1.* && \
+  pipx install aws-lambda-builders==1.2.0 && \
+  pipx install aws-sam-cli==1.15.0 && \
+  gem update --system --no-document && \
+  gem install --no-document bundler -v '~> 2.1'

--- a/runtimes/ruby3.2-x86_64/build/build.sh
+++ b/runtimes/ruby3.2-x86_64/build/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+docker build --progress plain --squash -t mlupin/docker-lambda:ruby3.2-build-x86_64 .

--- a/runtimes/ruby3.2-x86_64/build/publish.sh
+++ b/runtimes/ruby3.2-x86_64/build/publish.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+export PUBLISH_DATE=$(date "+%Y%m%d%H%M")
+export NO_ARCH_TAG="mlupin/docker-lambda:ruby3.2-build"
+export BASE_IMAGE="${NO_ARCH_TAG}-x86_64"
+
+docker tag ${BASE_IMAGE} ${BASE_IMAGE}-${PUBLISH_DATE}
+docker push ${BASE_IMAGE}
+docker push ${BASE_IMAGE}-${PUBLISH_DATE}

--- a/runtimes/ruby3.2-x86_64/run/Dockerfile
+++ b/runtimes/ruby3.2-x86_64/run/Dockerfile
@@ -1,0 +1,21 @@
+FROM amd64/amazonlinux:2
+
+RUN yum install -y tar gzip
+
+RUN curl https://docker-lambda.s3.amazonaws.com/fs/ruby3.2-x86_64.tgz | tar -zx -C /opt
+
+FROM mlupin/docker-lambda:provided.al2-x86_64
+FROM mlupin/docker-lambda:base-x86_64
+
+ENV PATH=/var/lang/bin:$PATH \
+    LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
+    AWS_EXECUTION_ENV=AWS_Lambda_ruby3.2 \
+    AWS_EXECUTION_ARCH=x86_64
+
+COPY --from=0 /opt/* /var/
+
+COPY --from=1 /var/runtime/init /var/rapid/init
+
+USER sbx_user1051
+
+ENTRYPOINT ["/var/rapid/init", "--bootstrap", "/var/runtime/bootstrap", "--enable-msg-logs"]

--- a/runtimes/ruby3.2-x86_64/run/build.sh
+++ b/runtimes/ruby3.2-x86_64/run/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+docker build --progress plain --squash -t mlupin/docker-lambda:ruby3.2-x86_64 .

--- a/runtimes/ruby3.2-x86_64/run/publish.sh
+++ b/runtimes/ruby3.2-x86_64/run/publish.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+export PUBLISH_DATE=$(date "+%Y%m%d%H%M")
+export NO_ARCH_TAG="mlupin/docker-lambda:ruby3.2"
+export BASE_IMAGE="${NO_ARCH_TAG}-x86_64"
+
+docker tag ${BASE_IMAGE} ${BASE_IMAGE}-${PUBLISH_DATE}
+docker push ${BASE_IMAGE}
+docker push ${BASE_IMAGE}-${PUBLISH_DATE}


### PR DESCRIPTION
Ref: https://github.com/mLupine/docker-lambda/issues/17

---

Hi @mLupine, thanks for keeping this project alive 😄 .

This PR aims to add the Ruby 3.2 runtime support since it's [supported by AWS](https://aws.amazon.com/blogs/compute/ruby-3-2-runtime-now-available-in-aws-lambda/) now :smile:

Please let me know if I missed something!
